### PR TITLE
Automatically Infer GitHub Field

### DIFF
--- a/commands/build.ts
+++ b/commands/build.ts
@@ -307,7 +307,7 @@ export default class Build extends BaseCommand {
         : tutorial;
       fs.writeFileSync(dest, newTutorial);
 
-      logger.log('success', `Tutorial has been written to ${chalk.bold(dest)}`);
+      logger.log('success', `Tutorial has been written to ${chalk.bold(dest)}.`);
     });
   }
 
@@ -345,6 +345,10 @@ export default class Build extends BaseCommand {
         'Cannot specify output target when tutorial splitting is enabled.',
       );
       this.exit(1);
+    }
+
+    if (flags.hexo && !tuture.github) {
+      logger.log('warning', 'No github field provided.');
     }
 
     const [tutorials, titles] = this.generateTutorials(tuture, rawDiffs);

--- a/commands/init.ts
+++ b/commands/init.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import chalk from 'chalk';
 import fs from 'fs-extra';
 import { flags } from '@oclif/command';
 import { prompt } from 'inquirer';
@@ -114,6 +115,15 @@ export default class Init extends BaseCommand {
         updated: new Date(),
         steps: await makeSteps(this.userConfig.ignoredFiles),
       };
+
+      const github = await git.inferGithubField();
+      if (github) {
+        logger.log(
+          'info',
+          `Inferred github repository: ${chalk.underline(github)}. Feel free to revise or delete it.`,
+        );
+        tuture.github = github;
+      }
 
       fs.writeFileSync(TUTURE_YML_PATH, yaml.safeDump(tuture));
 

--- a/utils/git.ts
+++ b/utils/git.ts
@@ -178,3 +178,30 @@ export function appendGitignore(config: any) {
     logger.log('info', '.gitignore rules appended.');
   }
 }
+
+/**
+ * Infer github field from available information.
+ */
+export async function inferGithubField() {
+  let github: string = '';
+  try {
+    // Trying to infer github repo url from origin.
+    github = await runGitCommand(['remote', 'get-url', 'origin']);
+    if (github) {
+      github = github.replace('.git', '').trim();
+    }
+  } catch {
+    // No remote url, infer github field from git username and cwd.
+    let username = await runGitCommand(['config', '--get', 'user.name']);
+    if (!username) {
+      username = await runGitCommand(['config', '--global', '--get', 'user.name']);
+    }
+
+    if (username) {
+      const { name: repoName } = path.parse(process.cwd());
+      github = `https://github.com/${username.trim()}/${repoName}`;
+    }
+  }
+
+  return github;
+}


### PR DESCRIPTION
- Infer `github` field when running `init` command
- Print a warning when tutorial is built into hexo blogs without a `github` field

P.S. I am also thinking of adding this feature  to `reload` command to ensure we have `github` field all the time, but it seems a little bit annoying for some users who do not have plans with GitHub. 
 Any thoughts?