### PR TITLE
Move build outputs to workspace

### DIFF
--- a/commands/build.ts
+++ b/commands/build.ts
@@ -95,7 +95,7 @@ export default class Build extends BaseCommand {
     help: flags.help({ char: 'h' }),
     out: flags.string({
       char: 'o',
-      description: 'name of output file',
+      description: 'name of output directory',
     }),
     hexo: flags.boolean({
       description: 'hexo compatibility mode',

--- a/config.ts
+++ b/config.ts
@@ -9,7 +9,7 @@ export default {
   assetsSyncInterval: 10000,
 
   // Path to build outputs.
-  buildPath: 'tuture-build',
+  buildPath: path.join(TUTURE_ROOT, 'build'),
 
   // Port to use for tuture-server.
   port: 3013,

--- a/utils/git.ts
+++ b/utils/git.ts
@@ -45,17 +45,10 @@ export async function storeDiff(commits: string[]) {
  * Append .tuture rule to gitignore.
  * If it's already ignored, do nothing.
  * If .gitignore doesn't exist, create one and add the rule.
- * @param config User config
  */
-export function appendGitignore(config: any) {
-  const ignoreRules = [
-    '# Tuture-related files\n',
-    TUTURE_ROOT,
-    config.buildPath,
-  ].join('\n');
-
+export function appendGitignore() {
   if (!fs.existsSync('.gitignore')) {
-    fs.writeFileSync('.gitignore', `${ignoreRules}\n`);
+    fs.writeFileSync('.gitignore', `${TUTURE_ROOT}\n`);
     logger.log('info', '.gitignore file created.');
   } else if (
     !fs
@@ -63,7 +56,7 @@ export function appendGitignore(config: any) {
       .toString()
       .includes(TUTURE_ROOT)
   ) {
-    fs.appendFileSync('.gitignore', `\n${ignoreRules}`);
+    fs.appendFileSync('.gitignore', `\n${TUTURE_ROOT}`);
     logger.log('info', '.gitignore rules appended.');
   }
 }


### PR DESCRIPTION
Now markdown outputs will be written to `.tuture/build` rather than `tuture-build`. This can make user's project root much cleaner.