### PR TITLE
Fix switchFile issue

### DIFF
--- a/editor/src/models/collection.tsx
+++ b/editor/src/models/collection.tsx
@@ -170,7 +170,13 @@ export const collection = {
         }
       });
 
-      updateNowSteps(state);
+      const { steps } = state.collection;
+
+      if (state.nowArticleId) {
+        state.nowSteps = flatten(unflattenedNowSteps);
+      } else {
+        state.nowSteps = flatten(steps);
+      }
 
       return state;
     },


### PR DESCRIPTION
As switchFile exist new define `unflattenSteps`, it cannot mutation origin steps, so, we need isolate it to update `state.nowSteps`